### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 [![Third Strand Studio](https://img.shields.io/badge/Third%20Strand%20Studio-Visit%20Us-blue)](https://thirdstrandstudio.com)
 
-
 MCP Server for executing XPath queries on XML content.
+
+<a href="https://glama.ai/mcp/servers/@thirdstrandstudio/mcp-xpath">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@thirdstrandstudio/mcp-xpath/badge" alt="mcp-xpath MCP server" />
+</a>
 
 ![image](https://github.com/user-attachments/assets/369045f3-1cdb-4204-9c62-0f5f32636262)
 


### PR DESCRIPTION
This PR adds a badge for the [mcp-xpath](https://glama.ai/mcp/servers/@thirdstrandstudio/mcp-xpath) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@thirdstrandstudio/mcp-xpath">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@thirdstrandstudio/mcp-xpath/badge" alt="mcp-xpath MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.